### PR TITLE
refactor(splitio-api-binding): just pass -1 as since value

### DIFF
--- a/lib/splitio-api-binding.js
+++ b/lib/splitio-api-binding.js
@@ -6,7 +6,6 @@ const axios = require('axios')
 
 const SPLITIO_API_URI = 'https://sdk.split.io/api'
 const SINCE_VALUE_FOR_FIRST_REQUEST = -1
-const DEFAULT_MAX_NUM_REQUESTS = 100
 
 const httpsAgent = new https.Agent({
   keepAlive: true,
@@ -56,39 +55,15 @@ class SplitioApiBinding {
   }
 
   /**
-   * Polls the Split.io API until since and till timestamps are the same.
-   * @param {String} path - The path of the HTTP request.
-   * @param {Integer} maxNumRequests - The maximum number of API requests to make
-   */
-  async getAllChanges ({ path, maxNumRequests = DEFAULT_MAX_NUM_REQUESTS }) {
-    let since = SINCE_VALUE_FOR_FIRST_REQUEST
-    let requestCount = 0
-    const allChanges = []
-    while (requestCount < maxNumRequests) {
-      const results = await this.httpGet({ path, since })
-      if (since === results.till) {
-        break
-      }
-      allChanges.push(results)
-      since = results.till
-      requestCount++
-    }
-    return { allChanges, since }
-  }
-
-  /**
    * Get split data.
    */
   async getSplitChanges () {
     const path = '/splitChanges'
-    const splitChanges = []
-    const { allChanges, since } = await this.getAllChanges({ path })
-    allChanges.forEach(change => {
-      change.splits.forEach(split => {
-        splitChanges.push(split)
-      })
+    const { splits, since } = await this.httpGet({
+      path,
+      since: SINCE_VALUE_FOR_FIRST_REQUEST
     })
-    return { splitChanges, since }
+    return { splitChanges: splits, since }
   }
 
   /**

--- a/lib/splitio-api-binding.test.js
+++ b/lib/splitio-api-binding.test.js
@@ -75,79 +75,17 @@ describe('lib.splitio-api-binding.SplitioApiBinding', () => {
     })
   })
 
-  describe('getAllChanges', () => {
-    const mockChanges0 = [{ bar: 'bar' }]
-    const mockChanges1 = [{ baz: 'baz' }]
-    const mockChanges2 = [{ zoo: 'zoo' }]
-    it('returns all changes and the since value', async () => {
-      const splitioApiBinding = new SplitioApiBinding({ splitioApiKey: 'foo' })
-      const requestStub = sinon.stub()
-      splitioApiBinding.httpGet = requestStub
-      requestStub.onCall(0).resolves({ changes: mockChanges0, till: 0 })
-      requestStub.onCall(1).resolves({ changes: mockChanges1, till: 1 })
-      requestStub.onCall(2).resolves({ changes: mockChanges2, till: 2 })
-      requestStub.onCall(3).resolves({ changes: mockChanges2, till: 2 })
-      const changes = await splitioApiBinding.getAllChanges({
-        path: '/mock',
-        maxNumRequests: 10
-      })
-      expect(changes).deep.equals({
-        allChanges: [
-          { changes: mockChanges0, till: 0 },
-          { changes: mockChanges1, till: 1 },
-          { changes: mockChanges2, till: 2 }
-        ],
-        since: 2
-      })
-    })
-
-    it('polls until the max number of requests is reached', async () => {
-      const splitioApiBinding = new SplitioApiBinding({ splitioApiKey: 'foo' })
-      const requestStub = sinon.stub()
-      splitioApiBinding.httpGet = requestStub
-      requestStub.onCall(0).resolves({ changes: mockChanges0, till: 0 })
-      requestStub.onCall(1).resolves({ changes: mockChanges1, till: 1 })
-      requestStub.onCall(2).resolves({ changes: mockChanges2, till: 2 })
-      requestStub.onCall(3).resolves({ changes: mockChanges2, till: 2 })
-      const changes = await splitioApiBinding.getAllChanges({
-        path: '/mock',
-        maxNumRequests: 2
-      })
-      expect(changes).deep.equals({
-        allChanges: [
-          { changes: mockChanges0, till: 0 },
-          { changes: mockChanges1, till: 1 }
-        ],
-        since: 1
-      })
-    })
-
-    it('throws an error on an error from httpGet', async () => {
-      const splitioApiBinding = new SplitioApiBinding({ splitioApiKey: 'foo' })
-      const requestStub = sinon.stub()
-      splitioApiBinding.httpGet = requestStub
-      requestStub.onCall(0).resolves({ changes: mockChanges0, till: 0 })
-      requestStub.onCall(1).rejects('Some Error')
-      try {
-        await splitioApiBinding.getAllChanges({ path: '/mock' })
-        throw new Error('did not throw')
-      } catch (err) {
-        expect(err).to.be.an.instanceof(Error)
-      }
-    })
-  })
-
   describe('getSplitChanges', () => {
     const mockSplits0 = { status: 'bar' }
     const mockSplits1 = { status: 'baz' }
     it('returns all splits and the since value', async () => {
       const splitioApiBinding = new SplitioApiBinding({ splitioApiKey: 'foo' })
       const requestStub = sinon.stub()
-      splitioApiBinding.getAllChanges = requestStub
+      splitioApiBinding.httpGet = requestStub
       requestStub.onCall(0).resolves({
-        allChanges: [
-          { splits: [mockSplits0], till: 0 },
-          { splits: [mockSplits1], till: 1 }
+        splits: [
+          mockSplits0,
+          mockSplits1
         ],
         since: 1
       })
@@ -164,7 +102,7 @@ describe('lib.splitio-api-binding.SplitioApiBinding', () => {
     it('throws an error on an error from getAllChanges', async () => {
       const splitioApiBinding = new SplitioApiBinding({ splitioApiKey: 'foo' })
       const requestStub = sinon.stub()
-      splitioApiBinding.getAllChanges = requestStub
+      splitioApiBinding.httpGet = requestStub
       requestStub.onCall(0).rejects('Some Error')
       try {
         await splitioApiBinding.getSplitChanges()


### PR DESCRIPTION
there's a bug in `getAllChanges` where we'd be getting duplicate entries for the same split if it had been edited and returned exactly during the time the while loop is running. that's unlikely but turns out we're not getting much benefit from `getAllChanges` anyway:

`GET /splitChanges` returns the latest state when since is `-1`, and should return the new state of splits (rather than a patch) on subsequent requests with different `since` values (though even after editing splits in the UI, i get an empty array of splits on following requests).

`GET /segmentChanges` returns the latest state when since is `-1` and patches indicating what was changed on subsequent requests with different `since` values. that means that `getAllChanges` as is won't work for segments either since duplicate values with differing state would get added to the output.

just using `-1` as since for now will work to get the latest state, and we can add support for iterating on `since` as a follow on
