### PR TITLE
fix(splito-api-binding): ensure latest splits are saved and add tests

### DIFF
--- a/lib/data-serializer.js
+++ b/lib/data-serializer.js
@@ -1,8 +1,5 @@
 'use strict'
 
-const Poller = require('./poller')
-const { SplitioApiBinding } = require('./splitio-api-binding')
-
 class DataSerializer {
   constructor ({ poller }) {
     this.poller = poller

--- a/lib/splitio-api-binding.js
+++ b/lib/splitio-api-binding.js
@@ -85,8 +85,9 @@ class SplitioApiBinding {
     const { allChanges, since } = await this.getAllChanges({ path })
     allChanges.forEach(change => {
       change.splits.forEach(split => {
-        if (split.status !== 'ARCHIVED') {
-          splits[split.name] = split
+        splits[split.name] = split
+        if (split.status === 'ARCHIVED') {
+          delete splits[split.name]
         }
       })
     })

--- a/lib/splitio-api-binding.js
+++ b/lib/splitio-api-binding.js
@@ -85,9 +85,10 @@ class SplitioApiBinding {
     const { allChanges, since } = await this.getAllChanges({ path })
     allChanges.forEach(change => {
       change.splits.forEach(split => {
-        splits[split.name] = split
         if (split.status === 'ARCHIVED') {
           delete splits[split.name]
+        } else {
+          splits[split.name] = split
         }
       })
     })

--- a/lib/splitio-api-binding.test.js
+++ b/lib/splitio-api-binding.test.js
@@ -169,7 +169,7 @@ describe('lib.splitio-api-binding', () => {
         })
       })
 
-      it('overwrites an existing split object will the latest data from a subsequent request', async () => {
+      it('overwrites an existing split object with the latest data from a subsequent request', async () => {
         const splitioApiBinding = new SplitioApiBinding({ splitioApiKey: 'foo' })
         const requestStub = sinon.stub()
         splitioApiBinding.getAllChanges = requestStub

--- a/lib/splitio-api-binding.test.js
+++ b/lib/splitio-api-binding.test.js
@@ -144,7 +144,10 @@ describe('lib.splitio-api-binding', () => {
     describe('getSplits', () => {
       const mockSplit0 = { name: 'mockSplit0', status: 'bar' }
       const mockSplit1 = { name: 'mockSplit1', status: 'baz' }
+      const mockSplit1Updated = { name: 'mockSplit1', status: 'zoo' }
       const mockSplit2 = { name: 'mockSplit2', status: 'ARCHIVED' }
+      const mockSplit3 = { name: 'mockSplit3', status: 'zaz' }
+      const mockSplit3Updated = { name: 'mockSplit3', status: 'ARCHIVED' }
       it('returns all active splits and the since value', async () => {
         const splitioApiBinding = new SplitioApiBinding({ splitioApiKey: 'foo' })
         const requestStub = sinon.stub()
@@ -161,6 +164,48 @@ describe('lib.splitio-api-binding', () => {
           splits: {
             mockSplit0,
             mockSplit1
+          },
+          since: 1
+        })
+      })
+
+      it('overwrites an existing split object will the latest data from a subsequent request', async () => {
+        const splitioApiBinding = new SplitioApiBinding({ splitioApiKey: 'foo' })
+        const requestStub = sinon.stub()
+        splitioApiBinding.getAllChanges = requestStub
+        requestStub.onCall(0).resolves({
+          allChanges: [
+            { splits: [mockSplit0, mockSplit1], till: 0 },
+            { splits: [mockSplit1Updated, mockSplit3], till: 1 }
+          ],
+          since: 1
+        })
+        const splits = await splitioApiBinding.getSplits({ path: '/splitChanges' })
+        expect(splits).deep.equals({
+          splits: {
+            mockSplit0,
+            mockSplit1: mockSplit1Updated,
+            mockSplit3
+          },
+          since: 1
+        })
+      })
+
+      it('does not save a split that was archived after the initial request to GET /splitChanges', async () => {
+        const splitioApiBinding = new SplitioApiBinding({ splitioApiKey: 'foo' })
+        const requestStub = sinon.stub()
+        splitioApiBinding.getAllChanges = requestStub
+        requestStub.onCall(0).resolves({
+          allChanges: [
+            { splits: [mockSplit0, mockSplit3], till: 0 },
+            { splits: [mockSplit3Updated], till: 1 }
+          ],
+          since: 1
+        })
+        const splits = await splitioApiBinding.getSplits({ path: '/splitChanges' })
+        expect(splits).deep.equals({
+          splits: {
+            mockSplit0
           },
           since: 1
         })


### PR DESCRIPTION
modify behavior in `getSplits` so that we don't save splits that have been archived after the initial request.

```
For Splits you'll receive again the full split object for each split that received changes since the last fetch. It's safe to assume that you can just overwrite the representation you had for that specific split, being the name of the split a unique id.

In case of the edge case, you'll hit it with -1 and again with a different value. The second request can come either empty (because you had up to date information) or with the updates that were not propagated yet.
````