### PR TITLE
fix(data-serializer): bug where we didn't stringify splits and segments

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ console.log(serializedDataScript)
 
 //<script>
 //  window.__splitCachePreload = {
-//    splitsData: {"split-1-name":{"name":"split-1-name","status":"bar"},"split-2-name":{"name":"split-2-name","status":"baz"}},
+//    splitsData: '{"split-1-name":{"name":"split-1-name","status":"bar"},"split-2-name":{"name":"split-2-name","status":"baz"}}',
 //    since: 1,
-//    segmentsData: {"test-segment":{"name":"test-segment","added":["foo","bar"]}},
+//    segmentsData: '{"test-segment":{"name":"test-segment","added":["foo","bar"]}}',
 //    usingSegmentsCount: 2
 //  };
 //</script>

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ console.log(serializedDataScript)
 //  window.__splitCachePreload = {
 //    splitsData: {"split-1-name":'{"name":"split-1-name","status":"bar"}',"split-2-name":'{"name":"split-2-name","status":"baz"}'},
 //    since: 1,
-//    segmentsData: '{"test-segment":{"name":"test-segment","added":["foo","bar"]}}',
+//    segmentsData: {"test-segment":'{"name":"test-segment","added":["foo","bar"]}'},
 //    usingSegmentsCount: 2
 //  };
 //</script>

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ console.log(serializedDataScript)
 
 //<script>
 //  window.__splitCachePreload = {
-//    splitsData: '{"split-1-name":{"name":"split-1-name","status":"bar"},"split-2-name":{"name":"split-2-name","status":"baz"}}',
+//    splitsData: {"split-1-name":'{"name":"split-1-name","status":"bar"}',"split-2-name":'{"name":"split-2-name","status":"baz"}'},
 //    since: 1,
 //    segmentsData: '{"test-segment":{"name":"test-segment","added":["foo","bar"]}}',
 //    usingSegmentsCount: 2

--- a/lib/data-serializer.js
+++ b/lib/data-serializer.js
@@ -21,7 +21,9 @@ class DataSerializer {
         acc[preloadKey] = latestCache[cacheKey]
         // Serialize values for splits and segments
         if(['splitsData', 'segmentsData'].includes(preloadKey)) {
-          Object.keys(acc[preloadKey]).forEach(key => acc[preloadKey][key] = JSON.stringify(acc[preloadKey][key]))
+          const data = acc[preloadKey]
+          Object.entries(data).forEach(([key, value]) => data[key] = JSON.stringify(value))
+          acc[preloadKey] = data
         }
       }
       return acc

--- a/lib/data-serializer.js
+++ b/lib/data-serializer.js
@@ -19,6 +19,10 @@ class DataSerializer {
     const splitCachePreload = keyMapping.reduce((acc, [preloadKey, cacheKey]) => {
       if (cacheKey in latestCache) {
         acc[preloadKey] = latestCache[cacheKey]
+        // Serialize values for splits and segments
+        if(['splitsData', 'segmentsData'].includes(preloadKey)) {
+          Object.keys(acc[preloadKey]).forEach(key => acc[preloadKey][key] = JSON.stringify(acc[preloadKey][key]))
+        }
       }
       return acc
     }, {})

--- a/lib/data-serializer.test.js
+++ b/lib/data-serializer.test.js
@@ -30,9 +30,14 @@ describe('lib.data-serializer.DataSerializer', () => {
       eval(res.replace('<script>', '').replace('</script>', ''))
       expect(window).to.deep.equal({
         __splitCachePreload: {
-          splitsData: mockSplitsObject,
+          splitsData: {
+            'split-1-name': '{"name":"split-1-name","status":"bar"}',
+            'split-2-name': '{"name":"split-2-name","status":"baz"}'
+          },
           since: 1,
-          segmentsData: mockSegmentsObject,
+          segmentsData: {
+            'test-segment': '{"name":"test-segment","added":["foo","bar"]}'
+          },
           usingSegmentsCount: 2
         }
       })


### PR DESCRIPTION
Quote from the doc: "The serialized data should be a list of strings that will be transformed into localStorage items for the SDK to consume."
https://docs.google.com/document/d/1kbAW7tzsnA8iimFeefiRMJWveyZhM8AJnLipIn8tKi0/edit?ts=5de591f6

The splits and segments data needs to be stringified for eventual storage in localstorage