### PR TITLE
[BREAKING CHANGE]feat(generateSerializedData): for a subset of splits, fetch updated segments data

### DIFF
--- a/lib/data-serializer.js
+++ b/lib/data-serializer.js
@@ -8,17 +8,16 @@ class DataSerializer {
   /**
    * Get latest split and segment data and return a script containing serialized strings.
    */
-  generateSerializedDataScript (splits = []) {
+  async generateSerializedDataScript (splits = []) {
     const serializedData = splits.length > 0
-      ? this._getFilteredSerializedData(splits)
+      ? await this._getFilteredSerializedData(splits)
       : this._getAllSerializedData()
-
     return `<script>
       window.__splitCachePreload = ${serializedData};
     </script>`
   }
 
-  _getFilteredSerializedData (splits) {
+  async _getFilteredSerializedData (splits) {
     return this.poller.getSerializedDataSubset(splits)
   }
 

--- a/lib/data-serializer.js
+++ b/lib/data-serializer.js
@@ -17,7 +17,7 @@ class DataSerializer {
     </script>`
   }
 
-  async _getFilteredSerializedData (splits) {
+  _getFilteredSerializedData (splits) {
     return this.poller.getSerializedDataSubset(splits)
   }
 

--- a/lib/data-serializer.test.js
+++ b/lib/data-serializer.test.js
@@ -6,7 +6,7 @@ const DataSerializer = require('./data-serializer')
 
 describe('lib.data-serializer.DataSerializer', () => {
   describe('generateSerializedDataScript', () => {
-    it('returns script with cached serializedData', () => {
+    it('returns script with cached serializedData', async () => {
       const dataSerializer = new DataSerializer({
         poller: {
           cache: {
@@ -14,7 +14,7 @@ describe('lib.data-serializer.DataSerializer', () => {
           }
         }
       })
-      const res = dataSerializer.generateSerializedDataScript()
+      const res = await dataSerializer.generateSerializedDataScript()
       const window = {}
       // eslint-disable-next-line no-eval
       eval(res.replace('<script>', '').replace('</script>', ''))
@@ -32,7 +32,7 @@ describe('lib.data-serializer.DataSerializer', () => {
         }
       })
     })
-    it('returns script with cached serializedData when there is a splits argument', () => {
+    it('returns script with cached serializedData when there is a splits argument', async () => {
       const dataSerializer = new DataSerializer({
         poller: {
           cache: {
@@ -41,7 +41,7 @@ describe('lib.data-serializer.DataSerializer', () => {
           getSerializedDataSubset: () => '{"splitsData":{"split-1-name":"{\\"name\\":\\"split-1-name\\",\\"status\\":\\"bar\\"}"},"since":1,"segmentsData":{"test-segment":"{\\"name\\":\\"test-segment\\",\\"added\\":[\\"foo\\",\\"bar\\"]}"},"usingSegmentsCount":2}'
         }
       })
-      const res = dataSerializer.generateSerializedDataScript(['split-1-name'])
+      const res = await dataSerializer.generateSerializedDataScript(['split-1-name'])
       const window = {}
       // eslint-disable-next-line no-eval
       eval(res.replace('<script>', '').replace('</script>', ''))
@@ -58,26 +58,26 @@ describe('lib.data-serializer.DataSerializer', () => {
         }
       })
     })
-    it('handles empty serializedData in poller cache', () => {
+    it('handles empty serializedData in poller cache', async () => {
       const dataSerializer = new DataSerializer({
         poller: {
           cache: {}
         }
       })
-      const res = dataSerializer.generateSerializedDataScript()
+      const res = await dataSerializer.generateSerializedDataScript()
       const window = {}
       // eslint-disable-next-line no-eval
       eval(res.replace('<script>', '').replace('</script>', ''))
       expect(window).to.deep.equal({ __splitCachePreload: {} })
     })
-    it('handles empty serializedData in poller cache when there is a splits argument', () => {
+    it('handles empty serializedData in poller cache when there is a splits argument', async () => {
       const dataSerializer = new DataSerializer({
         poller: {
           cache: {},
           getSerializedDataSubset: () => '{}'
         }
       })
-      const res = dataSerializer.generateSerializedDataScript(['foo'])
+      const res = await dataSerializer.generateSerializedDataScript(['foo'])
       const window = {}
       // eslint-disable-next-line no-eval
       eval(res.replace('<script>', '').replace('</script>', ''))

--- a/lib/poller.js
+++ b/lib/poller.js
@@ -55,6 +55,19 @@ class Poller extends EventEmitter {
 
   generateSerializedData (splits = []) {
     const latestCache = this.cache
+
+    // If generating serialized data for a subset of splits, get updated segments-related data for the subset
+    const serializingSegmentsForSubset = this.serializeSegments && splits.length !== 0
+    const updatedSegmentsData = {}
+    if (serializingSegmentsForSubset) {
+      Object.assign(updatedSegmentsData, JSON.parse(JSON.stringify(latestCache)))
+      const {
+        segments,
+        usingSegmentsCount
+      } = this.splitioApiBinding.getSegmentsForSplits({ splits })
+      Object.assign(updatedSegmentsData, { segments, usingSegmentsCount })
+    }
+
     const keyMapping = [
       ['splitsData', 'splits'],
       ['since', 'since'],
@@ -63,7 +76,7 @@ class Poller extends EventEmitter {
     ]
     const splitCachePreload = keyMapping.reduce((acc, [preloadKey, cacheKey]) => {
       if (cacheKey in latestCache) {
-        acc[preloadKey] = latestCache[cacheKey]
+        acc[preloadKey] = serializingSegmentsForSubset ? updatedSegmentsData[cacheKey] : latestCache[cacheKey]
         // Serialize values for splits and segments
         if (['splitsData', 'segmentsData'].includes(preloadKey)) {
           acc[preloadKey] = Object.entries(acc[preloadKey])

--- a/lib/poller.js
+++ b/lib/poller.js
@@ -60,7 +60,7 @@ class Poller extends EventEmitter {
     const serializingSegmentsForSubset = this.serializeSegments && splits.length
     const latestCacheForSubset = {}
     if (serializingSegmentsForSubset) {
-      Object.assign(latestCacheForSubset, JSON.parse(JSON.stringify(latestCache)))
+      Object.assign(latestCacheForSubset, latestCache)
       const {
         segments,
         usingSegmentsCount

--- a/lib/poller.js
+++ b/lib/poller.js
@@ -61,23 +61,10 @@ class Poller extends EventEmitter {
     const latestCacheForSubset = {}
     if (serializingSegmentsForSubset) {
       Object.assign(latestCacheForSubset, latestCache)
-      // Filter splits based on splits passed into function
-      const splitsSubset = Object.keys(latestCacheForSubset.splits)
-        .filter(key => splits.includes(key))
-        .reduce((obj, key) => {
-          return {
-            ...obj,
-            [key]: latestCacheForSubset.splits[key]
-          }
-        }, {})
-      let segments = {}
-      let usingSegmentsCount = 0
-      try {
-        ({
-          segments,
-          usingSegmentsCount
-        } = await this.splitioApiBinding.getSegmentsForSplits({ splits: splitsSubset }))
-      } catch (err) {}
+      const {
+        segments,
+        usingSegmentsCount
+      } = await this.getSegmentsDataForSubset(latestCacheForSubset, splits)
       Object.assign(latestCacheForSubset, { segments, usingSegmentsCount })
     }
 
@@ -108,6 +95,29 @@ class Poller extends EventEmitter {
     }, {})
 
     return JSON.stringify(splitCachePreload)
+  }
+
+  async getSegmentsDataForSubset (latestCacheForSubset, splits) {
+    // Filter splits based on splits passed into function
+    const splitsSubset = Object.keys(latestCacheForSubset.splits)
+      .filter(key => splits.includes(key))
+      .reduce((obj, key) => {
+        return {
+          ...obj,
+          [key]: latestCacheForSubset.splits[key]
+        }
+      }, {})
+
+    const subsetSegmentsData = { segments: {}, usingSegmentsCount: 0 }
+    try {
+      const {
+        segments,
+        usingSegmentsCount
+      } = await this.splitioApiBinding.getSegmentsForSplits({ splits: splitsSubset })
+      Object.assign(subsetSegmentsData, { segments, usingSegmentsCount })
+    } catch (err) {}
+
+    return subsetSegmentsData
   }
 
   async start () {

--- a/lib/poller.js
+++ b/lib/poller.js
@@ -57,7 +57,7 @@ class Poller extends EventEmitter {
     const latestCache = this.cache
 
     // If generating serialized data for a subset of splits, get updated segments-related data for the subset
-    const serializingSegmentsForSubset = this.serializeSegments && splits.length !== 0
+    const serializingSegmentsForSubset = this.serializeSegments && splits.length
     const latestCacheForSubset = {}
     if (serializingSegmentsForSubset) {
       Object.assign(latestCacheForSubset, JSON.parse(JSON.stringify(latestCache)))

--- a/lib/poller.js
+++ b/lib/poller.js
@@ -33,27 +33,27 @@ class Poller extends EventEmitter {
     } catch (err) {
       this.emit('error', err)
     }
-    Object.assign(this.cache, { serializedData: this.generateSerializedData() })
-    this.updateSerializedDataSubsets()
+    Object.assign(this.cache, { serializedData: await this.generateSerializedData() })
+    await this.updateSerializedDataSubsets()
   }
 
-  updateSerializedDataSubsets () {
-    Object.keys(this.cache.serializedDataSubsets).forEach(key => {
-      this.cache.serializedDataSubsets[key] = this.generateSerializedData(key.split('.'))
+  async updateSerializedDataSubsets () {
+    Object.keys(this.cache.serializedDataSubsets).forEach(async key => {
+      this.cache.serializedDataSubsets[key] = await this.generateSerializedData(key.split('.'))
     })
   }
 
-  getSerializedDataSubset (splits) {
+  async getSerializedDataSubset (splits) {
     const key = splits.sort().join('.')
     if (this.cache.serializedDataSubsets[key]) {
       return this.cache.serializedDataSubsets[key]
     }
-    const serializedData = this.generateSerializedData(splits)
+    const serializedData = await this.generateSerializedData(splits)
     this.cache.serializedDataSubsets[key] = serializedData
     return serializedData
   }
 
-  generateSerializedData (splits = []) {
+  async generateSerializedData (splits = []) {
     const latestCache = this.cache
 
     // If generating serialized data for a subset of splits, get updated segments-related data for the subset
@@ -61,10 +61,23 @@ class Poller extends EventEmitter {
     const latestCacheForSubset = {}
     if (serializingSegmentsForSubset) {
       Object.assign(latestCacheForSubset, latestCache)
-      const {
-        segments,
-        usingSegmentsCount
-      } = this.splitioApiBinding.getSegmentsForSplits({ splits })
+      // Filter splits based on splits passed into function
+      const splitsSubset = Object.keys(latestCacheForSubset.splits)
+        .filter(key => splits.includes(key))
+        .reduce((obj, key) => {
+          return {
+            ...obj,
+            [key]: latestCacheForSubset.splits[key]
+          }
+        }, {})
+      let segments = {}
+      let usingSegmentsCount = 0
+      try {
+        ({
+          segments,
+          usingSegmentsCount
+        } = await this.splitioApiBinding.getSegmentsForSplits({ splits: splitsSubset }))
+      } catch (err) {}
       Object.assign(latestCacheForSubset, { segments, usingSegmentsCount })
     }
 

--- a/lib/poller.js
+++ b/lib/poller.js
@@ -58,14 +58,14 @@ class Poller extends EventEmitter {
 
     // If generating serialized data for a subset of splits, get updated segments-related data for the subset
     const serializingSegmentsForSubset = this.serializeSegments && splits.length !== 0
-    const updatedSegmentsData = {}
+    const latestCacheForSubset = {}
     if (serializingSegmentsForSubset) {
-      Object.assign(updatedSegmentsData, JSON.parse(JSON.stringify(latestCache)))
+      Object.assign(latestCacheForSubset, JSON.parse(JSON.stringify(latestCache)))
       const {
         segments,
         usingSegmentsCount
       } = this.splitioApiBinding.getSegmentsForSplits({ splits })
-      Object.assign(updatedSegmentsData, { segments, usingSegmentsCount })
+      Object.assign(latestCacheForSubset, { segments, usingSegmentsCount })
     }
 
     const keyMapping = [
@@ -76,7 +76,7 @@ class Poller extends EventEmitter {
     ]
     const splitCachePreload = keyMapping.reduce((acc, [preloadKey, cacheKey]) => {
       if (cacheKey in latestCache) {
-        acc[preloadKey] = serializingSegmentsForSubset ? updatedSegmentsData[cacheKey] : latestCache[cacheKey]
+        acc[preloadKey] = serializingSegmentsForSubset ? latestCacheForSubset[cacheKey] : latestCache[cacheKey]
         // Serialize values for splits and segments
         if (['splitsData', 'segmentsData'].includes(preloadKey)) {
           acc[preloadKey] = Object.entries(acc[preloadKey])

--- a/lib/poller.test.js
+++ b/lib/poller.test.js
@@ -237,8 +237,11 @@ describe('lib.poller.Poller', () => {
         usingSegmentsCount: 2,
         serializedDataSubsets: {}
       }
+      const cacheBefore = JSON.parse(JSON.stringify(poller.cache))
+
       const res = poller.generateSerializedData(['split-1-name'])
       expect(res).to.equal('{"splitsData":{"split-1-name":"{\\"name\\":\\"split-1-name\\",\\"status\\":\\"bar\\"}"},"since":1,"segmentsData":{"mockSegment0":"{\\"name\\":\\"mockSegment0\\",\\"added\\":[]}"},"usingSegmentsCount":1}')
+      expect(poller.cache).to.deep.equal(cacheBefore)
     })
 
     it('handles empty caches', () => {

--- a/lib/poller.test.js
+++ b/lib/poller.test.js
@@ -160,30 +160,30 @@ describe('lib.poller.Poller', () => {
   })
 
   describe('getSerializedDataSubset', () => {
-    it('returns serializedData when the subset is not cached', () => {
+    it('returns serializedData when the subset is not cached', async () => {
       poller.cache = {
         splits: { mockSplit0: { name: 'mockSplit0', status: 'foo' } },
         since: 0,
         segments: {},
         serializedDataSubsets: {}
       }
-      const res = poller.getSerializedDataSubset(['mockSplit0'])
+      const res = await poller.getSerializedDataSubset(['mockSplit0'])
       expect(res).to.equal('{"splitsData":{"mockSplit0":"{\\"name\\":\\"mockSplit0\\",\\"status\\":\\"foo\\"}"},"since":0,"segmentsData":{}}')
     })
-    it('returns serializedData when the subset is cached', () => {
+    it('returns serializedData when the subset is cached', async () => {
       poller.cache = {
         splits: { mockSplit0: { name: 'mockSplit0', status: 'foo' } },
         since: 0,
         segments: {},
         serializedDataSubsets: { mockSplit0: 'cached split' }
       }
-      const res = poller.getSerializedDataSubset(['mockSplit0'])
+      const res = await poller.getSerializedDataSubset(['mockSplit0'])
       expect(res).to.equal('cached split')
     })
   })
 
   describe('generateSerializedData', () => {
-    it('returns stringified split and segment data', () => {
+    it('returns stringified split and segment data', async () => {
       const mockSplitsObject = {
         'split-1-name': { name: 'split-1-name', status: 'bar' },
         'split-2-name': { name: 'split-2-name', status: 'baz' }
@@ -198,11 +198,11 @@ describe('lib.poller.Poller', () => {
         usingSegmentsCount: 2,
         serializedDataSubsets: {}
       }
-      const res = poller.generateSerializedData()
+      const res = await poller.generateSerializedData()
       expect(res).to.equal('{"splitsData":{"split-1-name":"{\\"name\\":\\"split-1-name\\",\\"status\\":\\"bar\\"}","split-2-name":"{\\"name\\":\\"split-2-name\\",\\"status\\":\\"baz\\"}"},"since":1,"segmentsData":{"test-segment":"{\\"name\\":\\"test-segment\\",\\"added\\":[\\"foo\\",\\"bar\\"]}"},"usingSegmentsCount":2}')
     })
 
-    it('returns a subset of stringified split and segment data when given a list of splits', () => {
+    it('returns a subset of stringified split and segment data when given a list of splits', async () => {
       const mockSplitsObject = {
         'split-1-name': { name: 'split-1-name', status: 'bar' },
         'split-2-name': { name: 'split-2-name', status: 'baz' }
@@ -217,11 +217,11 @@ describe('lib.poller.Poller', () => {
         usingSegmentsCount: 2,
         serializedDataSubsets: {}
       }
-      const res = poller.generateSerializedData(['split-1-name'])
+      const res = await poller.generateSerializedData(['split-1-name'])
       expect(res).to.equal('{"splitsData":{"split-1-name":"{\\"name\\":\\"split-1-name\\",\\"status\\":\\"bar\\"}"},"since":1,"segmentsData":{"test-segment":"{\\"name\\":\\"test-segment\\",\\"added\\":[\\"foo\\",\\"bar\\"]}"},"usingSegmentsCount":2}')
     })
 
-    it('returns a subset of stringified split data and segments data from the mocked getSegmentsForSplits response', () => {
+    it('returns a subset of stringified split data and segments data from the mocked getSegmentsForSplits response', async () => {
       poller.serializeSegments = true
       const mockSplitsObject = {
         'split-1-name': { name: 'split-1-name', status: 'bar' },
@@ -239,18 +239,45 @@ describe('lib.poller.Poller', () => {
       }
       const cacheBefore = JSON.parse(JSON.stringify(poller.cache))
 
-      const res = poller.generateSerializedData(['split-1-name'])
+      const res = await poller.generateSerializedData(['split-1-name'])
       expect(res).to.equal('{"splitsData":{"split-1-name":"{\\"name\\":\\"split-1-name\\",\\"status\\":\\"bar\\"}"},"since":1,"segmentsData":{"mockSegment0":"{\\"name\\":\\"mockSegment0\\",\\"added\\":[]}"},"usingSegmentsCount":1}')
       expect(poller.cache).to.deep.equal(cacheBefore)
     })
 
-    it('handles empty caches', () => {
-      const res = poller.generateSerializedData()
+    it('returns empty segmentsData if error fetching segment data for a subset of splits', async () => {
+      poller.serializeSegments = true
+      const mockSplitsObject = {
+        'split-1-name': { name: 'split-1-name', status: 'bar' },
+        'split-2-name': { name: 'split-2-name', status: 'baz' }
+      }
+      const mockSegmentsObject = {
+        'test-segment': { name: 'test-segment', added: ['foo', 'bar'] }
+      }
+      poller.cache = {
+        splits: mockSplitsObject,
+        since: 1,
+        segments: mockSegmentsObject,
+        usingSegmentsCount: 2,
+        serializedDataSubsets: {}
+      }
+      const segmentsError = new Error('Error getting segments')
+      poller.splitioApiBinding = {
+        getSegmentsForSplits: () => {
+          throw segmentsError
+        }
+      }
+
+      const res = await poller.generateSerializedData(['split-1-name'])
+      expect(res).to.equal('{"splitsData":{"split-1-name":"{\\"name\\":\\"split-1-name\\",\\"status\\":\\"bar\\"}"},"since":1,"segmentsData":{},"usingSegmentsCount":0}')
+    })
+
+    it('handles empty caches', async () => {
+      const res = await poller.generateSerializedData()
       expect(res).to.equal('{}')
     })
 
-    it('handles empty caches with splits', () => {
-      const res = poller.generateSerializedData(['foo'])
+    it('handles empty caches with splits', async () => {
+      const res = await poller.generateSerializedData(['foo'])
       expect(res).to.equal('{}')
     })
   })

--- a/lib/poller.test.js
+++ b/lib/poller.test.js
@@ -20,6 +20,13 @@ describe('lib.poller.Poller', () => {
     },
     usingSegmentsCount: 1
   }
+  const mockSplitsObject = {
+    'split-1-name': { name: 'split-1-name', status: 'bar' },
+    'split-2-name': { name: 'split-2-name', status: 'baz' }
+  }
+  const mockSegmentsObject = {
+    'test-segment': { name: 'test-segment', added: ['foo', 'bar'] }
+  }
   beforeEach(() => {
     poller = new Poller({
       pollingRateSeconds: 0.1,
@@ -184,13 +191,6 @@ describe('lib.poller.Poller', () => {
 
   describe('generateSerializedData', () => {
     it('returns stringified split and segment data', async () => {
-      const mockSplitsObject = {
-        'split-1-name': { name: 'split-1-name', status: 'bar' },
-        'split-2-name': { name: 'split-2-name', status: 'baz' }
-      }
-      const mockSegmentsObject = {
-        'test-segment': { name: 'test-segment', added: ['foo', 'bar'] }
-      }
       poller.cache = {
         splits: mockSplitsObject,
         since: 1,
@@ -203,13 +203,6 @@ describe('lib.poller.Poller', () => {
     })
 
     it('returns a subset of stringified split and segment data when given a list of splits', async () => {
-      const mockSplitsObject = {
-        'split-1-name': { name: 'split-1-name', status: 'bar' },
-        'split-2-name': { name: 'split-2-name', status: 'baz' }
-      }
-      const mockSegmentsObject = {
-        'test-segment': { name: 'test-segment', added: ['foo', 'bar'] }
-      }
       poller.cache = {
         splits: mockSplitsObject,
         since: 1,
@@ -223,13 +216,6 @@ describe('lib.poller.Poller', () => {
 
     it('returns a subset of stringified split data and segments data from the mocked getSegmentsForSplits response', async () => {
       poller.serializeSegments = true
-      const mockSplitsObject = {
-        'split-1-name': { name: 'split-1-name', status: 'bar' },
-        'split-2-name': { name: 'split-2-name', status: 'baz' }
-      }
-      const mockSegmentsObject = {
-        'test-segment': { name: 'test-segment', added: ['foo', 'bar'] }
-      }
       poller.cache = {
         splits: mockSplitsObject,
         since: 1,
@@ -246,13 +232,6 @@ describe('lib.poller.Poller', () => {
 
     it('returns empty segmentsData if error fetching segment data for a subset of splits', async () => {
       poller.serializeSegments = true
-      const mockSplitsObject = {
-        'split-1-name': { name: 'split-1-name', status: 'bar' },
-        'split-2-name': { name: 'split-2-name', status: 'baz' }
-      }
-      const mockSegmentsObject = {
-        'test-segment': { name: 'test-segment', added: ['foo', 'bar'] }
-      }
       poller.cache = {
         splits: mockSplitsObject,
         since: 1,
@@ -279,6 +258,42 @@ describe('lib.poller.Poller', () => {
     it('handles empty caches with splits', async () => {
       const res = await poller.generateSerializedData(['foo'])
       expect(res).to.equal('{}')
+    })
+  })
+
+  describe('getSegmentsDataForSubset', () => {
+    it('returns mocked response for getSegmentsForSplits', async () => {
+      const latestCacheForSubset = {
+        splits: mockSplitsObject,
+        since: 1,
+        segments: mockSegmentsObject,
+        usingSegmentsCount: 2,
+        serializedDataSubsets: {}
+      }
+      const splits = ['split-1-name']
+
+      const res = await poller.getSegmentsDataForSubset(latestCacheForSubset, splits)
+      expect(res).to.deep.equal(mockGetSegmentsResult)
+    })
+
+    it('returns default segments data if error from getSegmentsForSplits', async () => {
+      const latestCacheForSubset = {
+        splits: mockSplitsObject,
+        since: 1,
+        segments: mockSegmentsObject,
+        usingSegmentsCount: 2,
+        serializedDataSubsets: {}
+      }
+      const splits = ['split-1-name']
+      const segmentsError = new Error('Error getting segments')
+      poller.splitioApiBinding = {
+        getSegmentsForSplits: () => {
+          throw segmentsError
+        }
+      }
+
+      const res = await poller.getSegmentsDataForSubset(latestCacheForSubset, splits)
+      expect(res).to.deep.equal({ segments: {}, usingSegmentsCount: 0 })
     })
   })
 })

--- a/lib/poller.test.js
+++ b/lib/poller.test.js
@@ -221,6 +221,26 @@ describe('lib.poller.Poller', () => {
       expect(res).to.equal('{"splitsData":{"split-1-name":"{\\"name\\":\\"split-1-name\\",\\"status\\":\\"bar\\"}"},"since":1,"segmentsData":{"test-segment":"{\\"name\\":\\"test-segment\\",\\"added\\":[\\"foo\\",\\"bar\\"]}"},"usingSegmentsCount":2}')
     })
 
+    it('returns a subset of stringified split data and segments data from the mocked getSegmentsForSplits response', () => {
+      poller.serializeSegments = true
+      const mockSplitsObject = {
+        'split-1-name': { name: 'split-1-name', status: 'bar' },
+        'split-2-name': { name: 'split-2-name', status: 'baz' }
+      }
+      const mockSegmentsObject = {
+        'test-segment': { name: 'test-segment', added: ['foo', 'bar'] }
+      }
+      poller.cache = {
+        splits: mockSplitsObject,
+        since: 1,
+        segments: mockSegmentsObject,
+        usingSegmentsCount: 2,
+        serializedDataSubsets: {}
+      }
+      const res = poller.generateSerializedData(['split-1-name'])
+      expect(res).to.equal('{"splitsData":{"split-1-name":"{\\"name\\":\\"split-1-name\\",\\"status\\":\\"bar\\"}"},"since":1,"segmentsData":{"mockSegment0":"{\\"name\\":\\"mockSegment0\\",\\"added\\":[]}"},"usingSegmentsCount":1}')
+    })
+
     it('handles empty caches', () => {
       const res = poller.generateSerializedData()
       expect(res).to.equal('{}')


### PR DESCRIPTION
**The issue being addressed**: For the case where we are generating serialized data for a subset of splits, the segments-related data will be gotten from the cache; the cache only contains data for _all_ splits.
**This change makes the fix such that**: For the above case, we serialize segments-related data that is tailored to the subset of splits.